### PR TITLE
add kodi to torrent2http.py

### DIFF
--- a/resources/site-packages/stream/torrent2http.py
+++ b/resources/site-packages/stream/torrent2http.py
@@ -10,6 +10,7 @@ from stream import plugin
 
 
 ANDROID_XBMC_IDS = [
+    "org.xbmc.kodi",                        # Stock Kodi
     "org.xbmc.xbmc",                        # Stock XBMC
     "tv.ouya.xbmc",                         # OUYA XBMC
     "com.semperpax.spmc",                   # SemPer Media Center (OUYA XBMC fork)


### PR DESCRIPTION
new kodi app_id breaks ANDROID_XBMC_IDS loop logic (line 44) as no else is provided android_binary_dir doesn't get defined and exception is raised (some additional logic rework is needed, this commit is a quickfix for kodi).